### PR TITLE
getting-started: correct LinkBuilder comments

### DIFF
--- a/getting-started/go.md
+++ b/getting-started/go.md
@@ -24,8 +24,8 @@ import (
 var linkBuilder = cidlink.LinkBuilder{cid.Prefix{
 	Version:  1,    // Usually '1'.
 	Codec:    0x71, // dag-cbor as per multicodec
-	MhType:   0x15, // sha3-384 as per multicodec
-	MhLength: 48,   // sha3-224 hash has a 48-byte sum.
+	MhType:   0x15, // sha3-384 as per multihash
+	MhLength: 48,   // sha3-384 hash has a 48-byte sum.
 }}
 ```
 


### PR DESCRIPTION
MhType and sha3-384 are a multihash, not a multicodec.

MhLength must correspond to MhType. The value does, but the comment
incorrectly referred to sha3-224 instead of sha3-384.