### PR TITLE
remove ipfs.start()

### DIFF
--- a/getting-started/js.md
+++ b/getting-started/js.md
@@ -110,7 +110,6 @@ import Block from '@ipld/block/defaults'
 import IPFS from 'ipfs'
 
 const ipfs = await IPFS.create()
-await ipfs.start()
 
 const save = async obj => {
   const block = Block.encoder(obj, 'dag-cbor')


### PR DESCRIPTION
on `ipfs` v0.52.3, this line threw an error:

```
/Users/harlan/code/core-network/vortex/spikes/ipld/node_modules/ipfs-core/src/utils/service.js:69
        throw new AlreadyStartedError()
              ^

AlreadyStartedError: cannot start, already started
    at Function.start (/Users/harlan/code/core-network/vortex/spikes/ipld/node_modules/ipfs-core/src/utils/service.js:69:15)
    at IPFS.start (/Users/harlan/code/core-network/vortex/spikes/ipld/node_modules/ipfs-core/src/components/start.js:20:47)
    at file:///Users/harlan/code/core-network/vortex/spikes/ipld/2.js:5:12 {
  code: 'ERR_ALREADY_STARTED'
}
```